### PR TITLE
Hide Google API key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,10 @@ plugins {
 
 apply plugin: 'com.mikepenz.aboutlibraries.plugin'
 
+def localPropertiesFile = rootProject.file("local.properties")
+def localProperties = new Properties()
+localProperties.load(new FileInputStream(localPropertiesFile))
+
 android {
     namespace 'com.starry.myne'
     compileSdk 33
@@ -19,6 +23,7 @@ android {
         versionCode 3
         versionName "1.1.1"
 
+        buildConfigField "String", "GOOGLE_API_KEY", localProperties['GOOGLE_API_KEY']
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary true

--- a/app/src/main/java/com/starry/myne/api/BooksApi.kt
+++ b/app/src/main/java/com/starry/myne/api/BooksApi.kt
@@ -17,6 +17,7 @@ limitations under the License.
 package com.starry.myne.api
 
 import com.google.gson.Gson
+import com.starry.myne.BuildConfig
 import com.starry.myne.api.models.BookSet
 import com.starry.myne.api.models.ExtraInfo
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +35,7 @@ object BooksApi {
 
     private const val BASE_URL = "https://gutendex.com/books"
     private const val GOOGLE_BOOKS_URL = "https://www.googleapis.com/books/v1/volumes"
-    private const val GOOGLE_API_KEY = "AIzaSyBCaXx-U0sbEpGVPWylSggC4RaR4gCGkVE"
+    private const val GOOGLE_API_KEY = BuildConfig.GOOGLE_API_KEY
 
 
     private val okHttpClient = OkHttpClient()


### PR DESCRIPTION
You've already included local.properties to the .gitignore file; simply add the api key in your local.properties.

Your API key should always be kept private to prevent misuse.
Anyone who clones this repository should use their own personal API key.
