### PR TITLE
Refactor settings backend

### DIFF
--- a/app/src/main/java/com/starry/myne/MainActivity.kt
+++ b/app/src/main/java/com/starry/myne/MainActivity.kt
@@ -43,7 +43,6 @@ import com.starry.myne.ui.screens.main.MainScreen
 import com.starry.myne.ui.screens.settings.viewmodels.SettingsViewModel
 import com.starry.myne.ui.screens.settings.viewmodels.ThemeMode
 import com.starry.myne.ui.theme.MyneTheme
-import com.starry.myne.utils.PreferenceUtil
 import dagger.hilt.android.AndroidEntryPoint
 
 @ExperimentalMaterialApi
@@ -61,22 +60,17 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        PreferenceUtil.initialize(this)
         networkObserver = NetworkObserver(applicationContext)
         settingsViewModel = ViewModelProvider(this)[SettingsViewModel::class.java]
         mainViewModel = ViewModelProvider(this)[MainViewModel::class.java]
 
-        when (PreferenceUtil.getInt(PreferenceUtil.APP_THEME_INT, ThemeMode.Auto.ordinal)) {
+        when (settingsViewModel.getThemeValue()) {
             ThemeMode.Auto.ordinal -> settingsViewModel.setTheme(ThemeMode.Auto)
             ThemeMode.Dark.ordinal -> settingsViewModel.setTheme(ThemeMode.Dark)
             ThemeMode.Light.ordinal -> settingsViewModel.setTheme(ThemeMode.Light)
         }
 
-        settingsViewModel.setMaterialYou(
-            PreferenceUtil.getBoolean(
-                PreferenceUtil.MATERIAL_YOU_BOOL, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-            )
-        )
+        settingsViewModel.setMaterialYou(settingsViewModel.getMaterialYouValue())
 
         // Install splash screen before setting content.
         installSplashScreen().setKeepOnScreenCondition {

--- a/app/src/main/java/com/starry/myne/di/MainModule.kt
+++ b/app/src/main/java/com/starry/myne/di/MainModule.kt
@@ -22,6 +22,7 @@ import com.starry.myne.database.MyneDatabase
 import com.starry.myne.others.BookDownloader
 import com.starry.myne.others.WelcomeDataStore
 import com.starry.myne.repo.BookRepository
+import com.starry.myne.utils.PreferenceUtil
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -55,6 +56,10 @@ class MainModule {
     @Singleton
     @Provides
     fun provideBookDownloader(@ApplicationContext context: Context) = BookDownloader(context)
+
+    @Singleton
+    @Provides
+    fun providePreferenceUtil(@ApplicationContext context: Context) = PreferenceUtil(context)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/starry/myne/ui/screens/home/composables/BookDetailScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/home/composables/BookDetailScreen.kt
@@ -356,17 +356,19 @@ fun BookDetailScreen(
                                                 viewModel.libraryDao.getItemById(book.id)!!
                                             withContext(Dispatchers.Main) {
                                                 Utils.openBookFile(
-                                                    context,
-                                                    libraryItem,
-                                                    navController
+                                                    context = context,
+                                                    internalReader = viewModel.getInternalReaderSetting(),
+                                                    libraryItem = libraryItem,
+                                                    navController = navController
                                                 )
                                             }
                                         }
                                     } else {
                                         Utils.openBookFile(
-                                            context,
-                                            bookLibraryItem,
-                                            navController
+                                            context = context,
+                                            internalReader = viewModel.getInternalReaderSetting(),
+                                            libraryItem = bookLibraryItem,
+                                            navController = navController
                                         )
                                     }
 

--- a/app/src/main/java/com/starry/myne/ui/screens/home/viewmodels/BookDetailViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/home/viewmodels/BookDetailViewModel.kt
@@ -36,6 +36,7 @@ import com.starry.myne.repo.models.Book
 import com.starry.myne.repo.models.BookSet
 import com.starry.myne.repo.models.ExtraInfo
 import com.starry.myne.utils.BookUtils
+import com.starry.myne.utils.PreferenceUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -58,8 +59,14 @@ class BookDetailViewModel @Inject constructor(
     private val bookRepository: BookRepository,
     val libraryDao: LibraryDao,
     val bookDownloader: BookDownloader,
+    private val preferenceUtil: PreferenceUtil
 ) : ViewModel() {
     var state by mutableStateOf(BookDetailScreenState())
+
+    fun getInternalReaderSetting() = preferenceUtil.getBoolean(
+        PreferenceUtil.INTERNAL_READER_BOOL, true
+    )
+
     fun getBookDetails(bookId: String) {
         viewModelScope.launch(Dispatchers.IO) {
             // Reset Screen state.

--- a/app/src/main/java/com/starry/myne/ui/screens/library/composables/LibraryScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/library/composables/LibraryScreen.kt
@@ -184,7 +184,10 @@ fun LibraryScreen(navController: NavController) {
                                         item.getDownloadDate(),
                                         onReadClick = {
                                             Utils.openBookFile(
-                                                context, item, navController
+                                                context = context,
+                                                internalReader = viewModel.getInternalReaderSetting(),
+                                                libraryItem = item,
+                                                navController = navController
                                             )
                                         },
                                         onDeleteClick = { openDeleteDialog.value = true })

--- a/app/src/main/java/com/starry/myne/ui/screens/library/viewmodels/LibraryViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/library/viewmodels/LibraryViewModel.kt
@@ -21,16 +21,24 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.starry.myne.database.library.LibraryDao
 import com.starry.myne.database.library.LibraryItem
+import com.starry.myne.utils.PreferenceUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class LibraryViewModel @Inject constructor(private val libraryDao: LibraryDao) : ViewModel() {
+class LibraryViewModel @Inject constructor(
+    private val libraryDao: LibraryDao,
+    private val preferenceUtil: PreferenceUtil
+) : ViewModel() {
     val allItems: LiveData<List<LibraryItem>> = libraryDao.getAllItems()
 
     fun deleteItem(item: LibraryItem) {
         viewModelScope.launch(Dispatchers.IO) { libraryDao.delete(item) }
     }
+
+    fun getInternalReaderSetting() = preferenceUtil.getBoolean(
+        PreferenceUtil.INTERNAL_READER_BOOL, true
+    )
 }

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/viewmodels/ReaderViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/viewmodels/ReaderViewModel.kt
@@ -71,7 +71,9 @@ data class ReaderScreenState(
 
 @HiltViewModel
 class ReaderViewModel @Inject constructor(
-    private val libraryDao: LibraryDao, private val readerDao: ReaderDao
+    private val libraryDao: LibraryDao,
+    private val readerDao: ReaderDao,
+    private val preferenceUtil: PreferenceUtil
 ) : ViewModel() {
     var state by mutableStateOf(ReaderScreenState())
 
@@ -102,16 +104,23 @@ class ReaderViewModel @Inject constructor(
     }
 
     fun setFontFamily(font: ReaderFont) {
-        PreferenceUtil.putString(PreferenceUtil.READER_FONT_STYLE_STR, font.id)
+        preferenceUtil.putString(PreferenceUtil.READER_FONT_STYLE_STR, font.id)
     }
 
     fun getFontFamily(): ReaderFont {
         return ReaderFont.getAllFonts().find {
-            it.id == PreferenceUtil.getString(
+            it.id == preferenceUtil.getString(
                 PreferenceUtil.READER_FONT_STYLE_STR,
                 ReaderFont.System.id
             )
         }!!
     }
+
+    fun setFontSize(newValue: Int) {
+        preferenceUtil.putInt(PreferenceUtil.READER_FONT_SIZE_INT, newValue)
+    }
+
+    fun getFontSize() = preferenceUtil.getInt(PreferenceUtil.READER_FONT_SIZE_INT, 100)
+
 
 }

--- a/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
@@ -55,7 +55,6 @@ import com.starry.myne.ui.navigation.Screens
 import com.starry.myne.ui.screens.settings.viewmodels.SettingsViewModel
 import com.starry.myne.ui.screens.settings.viewmodels.ThemeMode
 import com.starry.myne.ui.theme.figeronaFont
-import com.starry.myne.utils.PreferenceUtil
 import com.starry.myne.utils.getActivity
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -85,7 +84,7 @@ fun SettingsScreen(navController: NavController) {
             )
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 SettingsCard()
-                GeneralOptionsUI()
+                GeneralOptionsUI(viewModel = viewModel)
                 DisplayOptionsUI(viewModel = viewModel, context = context, snackBarHostState)
                 InformationUI(navController = navController)
             }
@@ -166,10 +165,8 @@ fun SettingsCard() {
 
 @ExperimentalMaterial3Api
 @Composable
-fun GeneralOptionsUI() {
-    val internalReaderValue = when (PreferenceUtil.getBoolean(
-        PreferenceUtil.INTERNAL_READER_BOOL, true
-    )) {
+fun GeneralOptionsUI(viewModel: SettingsViewModel) {
+    val internalReaderValue = when (viewModel.getInternalReaderValue()) {
         true -> "Internal Reader"
         false -> "External Reader"
     }
@@ -246,11 +243,11 @@ fun GeneralOptionsUI() {
 
                 when (selectedOption) {
                     "External Reader" -> {
-                        PreferenceUtil.putBoolean(PreferenceUtil.INTERNAL_READER_BOOL, false)
+                        viewModel.setInternalReaderValue(false)
                     }
 
                     "Internal Reader" -> {
-                        PreferenceUtil.putBoolean(PreferenceUtil.INTERNAL_READER_BOOL, true)
+                        viewModel.setInternalReaderValue(true)
                     }
                 }
             }) {
@@ -278,7 +275,7 @@ fun DisplayOptionsUI(
     snackbarHostState: SnackbarHostState,
 ) {
     val displayValue =
-        when (PreferenceUtil.getInt(PreferenceUtil.APP_THEME_INT, ThemeMode.Auto.ordinal)) {
+        when (viewModel.getThemeValue()) {
             ThemeMode.Light.ordinal -> "Light"
             ThemeMode.Dark.ordinal -> "Dark"
             else -> "System"
@@ -287,14 +284,7 @@ fun DisplayOptionsUI(
     val radioOptions = listOf("Light", "Dark", "System")
     val (selectedOption, onOptionSelected) = remember { mutableStateOf(displayValue) }
 
-    val materialYouSwitch = remember {
-        mutableStateOf(
-            PreferenceUtil.getBoolean(
-                PreferenceUtil.MATERIAL_YOU_BOOL, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-            )
-        )
-    }
-
+    val materialYouSwitch = remember { mutableStateOf(viewModel.getMaterialYouValue()) }
     val materialYouDesc = if (materialYouSwitch.value) {
         stringResource(id = R.string.material_you_settings_enabled_desc)
     } else {
@@ -329,7 +319,6 @@ fun DisplayOptionsUI(
     if (materialYouSwitch.value) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             viewModel.setMaterialYou(true)
-            PreferenceUtil.putBoolean(PreferenceUtil.MATERIAL_YOU_BOOL, true)
         } else {
             materialYouSwitch.value = false
             LaunchedEffect(
@@ -338,7 +327,6 @@ fun DisplayOptionsUI(
         }
     } else {
         viewModel.setMaterialYou(false)
-        PreferenceUtil.putBoolean(PreferenceUtil.MATERIAL_YOU_BOOL, false)
     }
 
     if (displayDialog.value) {
@@ -394,26 +382,17 @@ fun DisplayOptionsUI(
                         viewModel.setTheme(
                             ThemeMode.Light
                         )
-                        PreferenceUtil.putInt(
-                            PreferenceUtil.APP_THEME_INT, ThemeMode.Light.ordinal
-                        )
                     }
 
                     "Dark" -> {
                         viewModel.setTheme(
                             ThemeMode.Dark
                         )
-                        PreferenceUtil.putInt(
-                            PreferenceUtil.APP_THEME_INT, ThemeMode.Dark.ordinal
-                        )
                     }
 
                     "System" -> {
                         viewModel.setTheme(
                             ThemeMode.Auto
-                        )
-                        PreferenceUtil.putInt(
-                            PreferenceUtil.APP_THEME_INT, ThemeMode.Auto.ordinal
                         )
                     }
                 }

--- a/app/src/main/java/com/starry/myne/ui/screens/settings/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/settings/viewmodels/SettingsViewModel.kt
@@ -22,12 +22,18 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.starry.myne.utils.PreferenceUtil
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
 enum class ThemeMode {
     Light, Dark, Auto
 }
 
-class SettingsViewModel : ViewModel() {
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val preferenceUtil: PreferenceUtil
+) : ViewModel() {
 
     private val _theme = MutableLiveData(ThemeMode.Auto)
     private val _materialYou = MutableLiveData(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
@@ -37,11 +43,29 @@ class SettingsViewModel : ViewModel() {
 
     fun setTheme(newTheme: ThemeMode) {
         _theme.postValue(newTheme)
+        preferenceUtil.putInt(PreferenceUtil.APP_THEME_INT, newTheme.ordinal)
     }
 
     fun setMaterialYou(newValue: Boolean) {
         _materialYou.postValue(newValue)
+        preferenceUtil.putBoolean(PreferenceUtil.MATERIAL_YOU_BOOL, newValue)
     }
+
+    fun setInternalReaderValue(newValue: Boolean) {
+        preferenceUtil.putBoolean(PreferenceUtil.INTERNAL_READER_BOOL, newValue)
+    }
+
+    fun getMaterialYouValue() = preferenceUtil.getBoolean(
+        PreferenceUtil.MATERIAL_YOU_BOOL, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    )
+
+    fun getThemeValue() = preferenceUtil.getInt(
+        PreferenceUtil.APP_THEME_INT, ThemeMode.Auto.ordinal
+    )
+
+    fun getInternalReaderValue() = preferenceUtil.getBoolean(
+        PreferenceUtil.INTERNAL_READER_BOOL, true
+    )
 
     @Composable
     fun getCurrentTheme(): ThemeMode {

--- a/app/src/main/java/com/starry/myne/ui/screens/welcome/composables/WelcomeScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/welcome/composables/WelcomeScreen.kt
@@ -64,15 +64,12 @@ import com.starry.myne.R
 import com.starry.myne.ui.navigation.BottomBarScreen
 import com.starry.myne.ui.screens.welcome.viewmodels.WelcomeViewModel
 import com.starry.myne.ui.theme.figeronaFont
-import com.starry.myne.utils.PreferenceUtil
 
 @Composable
 fun WelcomeScreen(navController: NavController) {
     val viewModel: WelcomeViewModel = hiltViewModel()
 
-    val internalReaderValue = when (PreferenceUtil.getBoolean(
-        PreferenceUtil.INTERNAL_READER_BOOL, true
-    )) {
+    val internalReaderValue = when (viewModel.getInternalReaderSetting()) {
         true -> "Internal Reader"
         false -> "External Reader"
     }
@@ -208,11 +205,11 @@ fun WelcomeScreen(navController: NavController) {
 
                     when (selectedOption) {
                         "External Reader" -> {
-                            PreferenceUtil.putBoolean(PreferenceUtil.INTERNAL_READER_BOOL, false)
+                            viewModel.setInternalReaderSetting(false)
                         }
 
                         "Internal Reader" -> {
-                            PreferenceUtil.putBoolean(PreferenceUtil.INTERNAL_READER_BOOL, true)
+                            viewModel.setInternalReaderSetting(true)
                         }
                     }
                 }) {

--- a/app/src/main/java/com/starry/myne/ui/screens/welcome/viewmodels/WelcomeViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/welcome/viewmodels/WelcomeViewModel.kt
@@ -20,6 +20,7 @@ package com.starry.myne.ui.screens.welcome.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.starry.myne.others.WelcomeDataStore
+import com.starry.myne.utils.PreferenceUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -27,7 +28,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WelcomeViewModel @Inject constructor(
-    private val welcomeDataStore: WelcomeDataStore
+    private val welcomeDataStore: WelcomeDataStore,
+    private val preferenceUtil: PreferenceUtil
 ) : ViewModel() {
 
     fun saveOnBoardingState(completed: Boolean) {
@@ -35,4 +37,13 @@ class WelcomeViewModel @Inject constructor(
             welcomeDataStore.saveOnBoardingState(completed = completed)
         }
     }
+
+
+    fun setInternalReaderSetting(newValue: Boolean) {
+        preferenceUtil.putBoolean(PreferenceUtil.INTERNAL_READER_BOOL, newValue)
+    }
+
+    fun getInternalReaderSetting() = preferenceUtil.getBoolean(
+        PreferenceUtil.INTERNAL_READER_BOOL, true
+    )
 }

--- a/app/src/main/java/com/starry/myne/utils/Preferencesutils.kt
+++ b/app/src/main/java/com/starry/myne/utils/Preferencesutils.kt
@@ -19,18 +19,22 @@ package com.starry.myne.utils
 import android.content.Context
 import android.content.SharedPreferences
 
-object PreferenceUtil {
+class PreferenceUtil(context: Context) {
+
+    companion object {
+        private const val PREFS_NAME = "myne_settings"
+
+        // Preference keys
+        const val APP_THEME_INT = "theme_settings"
+        const val MATERIAL_YOU_BOOL = "material_you"
+        const val INTERNAL_READER_BOOL = "internal_reader"
+        const val READER_FONT_SIZE_INT = "reader_font_size"
+        const val READER_FONT_STYLE_STR = "reader_font_style"
+    }
+
     private lateinit var prefs: SharedPreferences
-    private const val PREFS_NAME = "myne_settings"
 
-    // Preference keys
-    const val APP_THEME_INT = "theme_settings"
-    const val MATERIAL_YOU_BOOL = "material_you"
-    const val INTERNAL_READER_BOOL = "internal_reader"
-    const val READER_FONT_SIZE_INT = "reader_font_size"
-    const val READER_FONT_STYLE_STR = "reader_font_style"
-
-    fun initialize(context: Context) {
+    init {
         prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     }
 

--- a/app/src/main/java/com/starry/myne/utils/Utils.kt
+++ b/app/src/main/java/com/starry/myne/utils/Utils.kt
@@ -47,17 +47,18 @@ object Utils {
         }
     }
 
-    fun openBookFile(context: Context, item: LibraryItem, navController: NavController) {
+    fun openBookFile(
+        context: Context,
+        internalReader: Boolean,
+        libraryItem: LibraryItem,
+        navController: NavController
+    ) {
 
-        if (PreferenceUtil.getBoolean(PreferenceUtil.INTERNAL_READER_BOOL, true)) {
-            navController.navigate(
-                Screens.ReaderDetailScreen.withBookId(
-                    item.bookId.toString()
-                )
-            )
+        if (internalReader) {
+            navController.navigate(Screens.ReaderDetailScreen.withBookId(libraryItem.bookId.toString()))
         } else {
             val uri = FileProvider.getUriForFile(
-                context, BuildConfig.APPLICATION_ID + ".provider", File(item.filePath)
+                context, BuildConfig.APPLICATION_ID + ".provider", File(libraryItem.filePath)
             )
             val intent = Intent(Intent.ACTION_VIEW)
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)


### PR DESCRIPTION
- Use dependency injection to inject preference utils in ViewModels.
- Use ViewModels to delegate calls to preference utils instead of directly calling it inside the UI, resulting in overall more readable and less error prone code.