### PR TITLE
Fix crash due to `asImageBitmap()` call in e-book reader

### DIFF
--- a/app/src/main/java/com/starry/myne/ui/screens/reader/composables/ReaderDetailScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/composables/ReaderDetailScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -134,8 +133,8 @@ fun ReaderDetailScreen(
                     .background(MaterialTheme.colorScheme.background)
                     .padding(it)
             ) {
-                val imageData = state.ebookData!!.coverImage
-                    ?: state.ebookData.epubBook.coverImage?.asImageBitmap()
+                // Get the cover image data.
+                val imageData = state.ebookData!!.coverImage ?: state.ebookData.epubBook.coverImage
 
                 BookDetailTopUI(
                     title = state.ebookData.title,

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlin_version = '1.9.22'
-        gradle_version = '8.3.1'
+        gradle_version = '8.3.2'
         hilt_version = '2.49'
         room_version = '2.6.1'
     }


### PR DESCRIPTION
Apparently, coil don't support `ImageBitmap`, but do support the regular bitmaps.
While on that, also bump AGP version