### PR TITLE
epub-parser: find siblings from parent's sibling node aswell

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">

--- a/app/src/main/java/com/starry/myne/epub/EpubUtils.kt
+++ b/app/src/main/java/com/starry/myne/epub/EpubUtils.kt
@@ -20,6 +20,7 @@ package com.starry.myne.epub
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Node
+import org.jsoup.nodes.Node as JsoupNode
 import org.w3c.dom.NodeList
 import org.xml.sax.InputSource
 import java.io.File
@@ -58,3 +59,13 @@ fun Node.getAttributeValue(attribute: String): String? =
 
 val NodeList.elements get() = (0..length).asSequence().mapNotNull { item(it) as? Element }
 val Node.childElements get() = childNodes.elements
+
+fun JsoupNode.nextSiblingNodes(): List<org.jsoup.nodes.Node> {
+    val siblings = mutableListOf<org.jsoup.nodes.Node>()
+    var nextSibling = nextSibling()
+    while (nextSibling != null) {
+        siblings.add(nextSibling)
+        nextSibling = nextSibling.nextSibling()
+    }
+    return siblings
+}


### PR DESCRIPTION
Currently, the EPUB parser only finds siblings located inside its own parent, which may result in an empty or incomplete chapter body if some of the sibling nodes are located within the siblings of its parent node instead of being direct siblings.