### PR TITLE
fix: epub-parser: Fallback to spine based parsing method if `navMap` is empty

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,7 +147,7 @@ dependencies {
     // Crash Handler.
     implementation 'cat.ereza:customactivityoncrash:2.4.0'
     // Kotlin reflect API.
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.9.22"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.9.24"
     // Testing components.
     testImplementation 'junit:junit:4.13.2'
     testImplementation "com.google.truth:truth:1.1.3"

--- a/app/src/main/java/com/starry/myne/MainViewModel.kt
+++ b/app/src/main/java/com/starry/myne/MainViewModel.kt
@@ -50,7 +50,7 @@ class MainViewModel @Inject constructor(private val welcomeDataStore: WelcomeDat
                     _startDestination.value = Screens.WelcomeScreen.route
                 }
 
-                delay(180)
+                delay(150)
                 _isLoading.value = false
             }
         }

--- a/app/src/main/java/com/starry/myne/epub/EpubParser.kt
+++ b/app/src/main/java/com/starry/myne/epub/EpubParser.kt
@@ -128,6 +128,7 @@ class EpubParser {
         inputStream.use { return parseAndCreateEbook(it, shouldUseToc) }
     }
 
+    // Parses the EPUB file and creates an EpubBook object.
     private suspend fun parseAndCreateEbook(
         inputStream: InputStream, shouldUseToc: Boolean
     ): EpubBook = withContext(Dispatchers.IO) {
@@ -196,6 +197,7 @@ class EpubParser {
 
     }
 
+    // Get all of the files located in the EPUB archive.
     private suspend fun getZipFiles(
         inputStream: InputStream
     ): Map<String, EpubFile> = withContext(Dispatchers.IO) {
@@ -206,6 +208,7 @@ class EpubParser {
         }
     }
 
+    // Create an EpubDocument object from the EPUB files.
     @Throws(EpubParserException::class)
     private fun createEpubDocument(files: Map<String, EpubFile>): EpubDocument {
         val container = files["META-INF/container.xml"]
@@ -229,6 +232,7 @@ class EpubParser {
         return EpubDocument(metadata, manifest, spine, opfFilePath)
     }
 
+    // Find all nested navPoints in the table of contents (ToC) file.
     private fun findNestedNavPoints(element: Element?): List<Element> {
         val navPoints = mutableListOf<Element>()
         if (element == null) {
@@ -244,6 +248,7 @@ class EpubParser {
         return navPoints
     }
 
+    // Parse chapters based on the table of contents (ToC) file.
     private fun parseUsingTocFile(
         tocNavPoints: List<Element>, files: Map<String, EpubFile>, hrefRootPath: File
     ): List<EpubChapter> {
@@ -296,6 +301,8 @@ class EpubParser {
         }.filter { it.body.isNotBlank() }.toList()
     }
 
+    // Parse chapters based on the spine of the epub document.
+    // This is the fallback method if the ToC file is not available or shouldUseToc is false.
     private fun parseUsingSpine(
         spine: Node,
         manifestItems: Map<String, EpubManifestItem>,

--- a/app/src/main/java/com/starry/myne/epub/EpubParserException.kt
+++ b/app/src/main/java/com/starry/myne/epub/EpubParserException.kt
@@ -1,0 +1,8 @@
+package com.starry.myne.epub
+
+/**
+ * Exception thrown when an error occurs while parsing an EPUB file.
+ *
+ * @param message The error message.
+ */
+class EpubParserException(message: String) : Exception(message)

--- a/app/src/main/java/com/starry/myne/epub/EpubUtils.kt
+++ b/app/src/main/java/com/starry/myne/epub/EpubUtils.kt
@@ -60,8 +60,8 @@ fun Node.getAttributeValue(attribute: String): String? =
 val NodeList.elements get() = (0..length).asSequence().mapNotNull { item(it) as? Element }
 val Node.childElements get() = childNodes.elements
 
-fun JsoupNode.nextSiblingNodes(): List<org.jsoup.nodes.Node> {
-    val siblings = mutableListOf<org.jsoup.nodes.Node>()
+fun JsoupNode.nextSiblingNodes(): List<JsoupNode> {
+    val siblings = mutableListOf<JsoupNode>()
     var nextSibling = nextSibling()
     while (nextSibling != null) {
         siblings.add(nextSibling)

--- a/app/src/main/java/com/starry/myne/helpers/Preferencesutils.kt
+++ b/app/src/main/java/com/starry/myne/helpers/Preferencesutils.kt
@@ -19,6 +19,11 @@ package com.starry.myne.helpers
 import android.content.Context
 import android.content.SharedPreferences
 
+/**
+ * A helper class to manage shared preferences
+ *
+ * @param context The context to use
+ */
 class PreferenceUtil(context: Context) {
 
     companion object {
@@ -38,40 +43,80 @@ class PreferenceUtil(context: Context) {
         const val LIBRARY_SWIPE_TOOLTIP_BOOL = "show_library_tooltip"
     }
 
-    private var prefs: SharedPreferences
+    //
+    private var prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-    init {
-        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    }
-
+    /**
+     * Check if a key exists in the preferences
+     *
+     * @param key The key to check
+     * @return True if the key exists, false otherwise
+     */
     fun keyExists(key: String): Boolean = prefs.contains(key)
 
+    /**
+     * Insert a string value into the preferences
+     *
+     * @param key The key to insert the value into
+     * @param value The value to insert
+     */
     fun putString(key: String, value: String) {
         val prefsEditor = prefs.edit()
         prefsEditor.putString(key, value)
         prefsEditor.apply()
     }
 
+    /**
+     * Insert an integer value into the preferences
+     *
+     * @param key The key to insert the value into
+     * @param value The value to insert
+     */
     fun putInt(key: String, value: Int) {
         val prefsEditor = prefs.edit()
         prefsEditor.putInt(key, value)
         prefsEditor.apply()
     }
 
+    /**
+     * Insert a boolean value into the preferences
+     *
+     * @param key The key to insert the value into
+     * @param value The value to insert
+     */
     fun putBoolean(key: String, value: Boolean) {
         val prefsEditor = prefs.edit()
         prefsEditor.putBoolean(key, value)
         prefsEditor.apply()
     }
 
+    /**
+     * Get a string value from the preferences
+     *
+     * @param key The key to get the value from
+     * @param defValue The default value to return if the key does not exist
+     */
     fun getString(key: String, defValue: String): String? {
         return prefs.getString(key, defValue)
     }
 
+    /**
+     * Get an integer value from the preferences
+     *
+     * @param key The key to get the value from
+     * @param defValue The default value to return if the key does not exist
+     */
     fun getInt(key: String, defValue: Int): Int {
         return prefs.getInt(key, defValue)
     }
 
+    /**
+     * Get a boolean value from the preferences
+     *
+     * @param key The key to get the value from
+     * @param defValue The default value to return if the key does not exist
+     */
     fun getBoolean(key: String, defValue: Boolean): Boolean {
         return prefs.getBoolean(key, defValue)
     }

--- a/app/src/main/java/com/starry/myne/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/main/MainScreen.kt
@@ -17,15 +17,11 @@
 package com.starry.myne.ui.screens.main
 
 import android.annotation.SuppressLint
-import androidx.activity.SystemBarStyle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -41,7 +37,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,7 +54,6 @@ import androidx.navigation.compose.rememberNavController
 import com.starry.myne.helpers.NetworkObserver
 import com.starry.myne.ui.navigation.BottomBarScreen
 import com.starry.myne.ui.navigation.NavGraph
-import com.starry.myne.ui.screens.settings.viewmodels.ThemeMode
 import com.starry.myne.ui.theme.figeronaFont
 
 /**

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/activities/ReaderActivity.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/activities/ReaderActivity.kt
@@ -75,7 +75,8 @@ class ReaderActivity : AppCompatActivity() {
         // Fullscreen mode that ignores any cutout, notch etc.
         WindowCompat.setDecorFitsSystemWindows(window, false)
         val controller = WindowInsetsControllerCompat(window, window.decorView)
-        controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        controller.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         controller.hide(WindowInsetsCompat.Type.systemBars())
         controller.hide(WindowInsetsCompat.Type.displayCutout())
 

--- a/app/src/test/java/com/starry/myne/EpubParserTest.kt
+++ b/app/src/test/java/com/starry/myne/EpubParserTest.kt
@@ -33,7 +33,7 @@ import java.util.zip.ZipOutputStream
 import kotlin.random.Random
 
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest=Config.NONE, sdk=[33]) // Run on Android 13
+@Config(manifest = Config.NONE, sdk = [33]) // Run on Android 13
 class EpubParserTest {
 
     private lateinit var epubParser: EpubParser


### PR DESCRIPTION
Closes #177 