### PR TITLE
fastlane: slightly improve full descriptions

### DIFF
--- a/fastlane/metadata/android/cs-CZ/full_description.txt
+++ b/fastlane/metadata/android/cs-CZ/full_description.txt
@@ -11,3 +11,5 @@ Funkce:
 - MAD: uživatelské rozhraní a logika napsané v čistém jazyce Kotlin. Jedna aktivita, žádné fragmenty, pouze složitelné cíle.
 
 PS: *Název aplikace je inspirován hlavním hrdinou anime s názvem Ascendance of a Bookworm (Honzuki no gekokudžó).*
+
+Poznámka: Aplikace také využívá rozhraní <a href='https://books.google.co.in/'>Google Books</a> API k získání některých dalších údajů, jako je shrnutí knihy, počet stránek atd., protože projekt GutenBerg tyto hodnoty do svých metadat nezahrnuje. Snaží se co nejlépe mapovat data získaná z knih Google s metadaty Gutenbergu, ale mapování není 100% přesné a ne všechny knihy dostupné na GutenBerg jsou dostupné i na Google books nebo jsou dostupné, ale s jiným názvem, takže můžete najít některé knihy bez souhrnu nebo počtu stran atd.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -11,3 +11,5 @@ Highlights:
 - MAD: UI and logic written with pure Kotlin. Single activity, no fragments, only composable destinations.
 
 PS: *The name of the app is inspired from the main character of an anime called Ascendance of a Bookworm.*
+
+Note: The app also uses the <a href='https://books.google.co.in/'>Google Books</a> API to fetch some extra data like book summary and pages count etc, as the GutenBerg project don't include those values in their metadata. It tries it's best to map the data received from Google books with Gutenberg's metadata but the mapping is not 100% accurate and not all books available on GutenBerg is also available on Google books or is available but with different title, so you may find some books without summary or page count etc.

--- a/fastlane/metadata/android/ro/full_description.txt
+++ b/fastlane/metadata/android/ro/full_description.txt
@@ -11,3 +11,5 @@ Aspecte importante:
 - MAD: UI și logică scrise cu Kotlin pur. Activitate unică, fără fragmente, doar destinații compozibile.
 
 PS: *Numele aplicației este inspirat de personajul principal al unui anime numit Ascendance of a Bookworm.
+
+Notă: Aplicația utilizează, de asemenea, API-ul <a href='https://books.google.co.in/'>Google Books</a> pentru a obține unele date suplimentare, cum ar fi rezumatul cărții și numărul de pagini etc., deoarece proiectul GutenBerg nu include aceste valori în metadatele sale. Aplicația face tot posibilul pentru a corela datele primite de la Google Books cu metadatele Gutenberg, dar corelarea nu este 100% exactă și nu toate cărțile disponibile pe GutenBerg sunt disponibile și pe Google Books sau sunt disponibile dar cu un titlu diferit, astfel încât este posibil să găsiți unele cărți fără rezumat sau număr de pagini etc.


### PR DESCRIPTION
Just adding a hint to the full description that the Google Books API is being used, for transparency (and to avoid "bad surprises" :wink:)