### PR TITLE
feat(ui): Added dnd feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 
     <application
         android:name=".MyneApp"

--- a/app/src/main/java/com/starry/myne/MainActivity.kt
+++ b/app/src/main/java/com/starry/myne/MainActivity.kt
@@ -16,6 +16,7 @@
 
 package com.starry.myne
 
+import android.app.NotificationManager
 import android.content.pm.ShortcutManager
 import android.os.Bundle
 import android.util.Log

--- a/app/src/main/java/com/starry/myne/helpers/Preferencesutils.kt
+++ b/app/src/main/java/com/starry/myne/helpers/Preferencesutils.kt
@@ -34,6 +34,7 @@ class PreferenceUtil(context: Context) {
         const val INTERNAL_READER_BOOL = "internal_reader"
         const val USE_GOOGLE_API_BOOL = "use_google_books_api"
         const val OPEN_LIBRARY_AT_START_BOOL = "launch_library_at_start"
+        const val ENABLE_ZEN_MODE_BOOL = "enable_zen_mode"
 
         // App theme preference keys
         const val APP_THEME_INT = "theme_settings"
@@ -65,6 +66,7 @@ class PreferenceUtil(context: Context) {
                 OPEN_LIBRARY_AT_START_BOOL,
                 false
             )
+            if (!keyExists(ENABLE_ZEN_MODE_BOOL)) putBoolean(ENABLE_ZEN_MODE_BOOL, false)
         }
     }
 

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/detail/ReaderDetailScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/detail/ReaderDetailScreen.kt
@@ -17,7 +17,12 @@
 
 package com.starry.myne.ui.screens.reader.detail
 
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.util.Log
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -42,10 +47,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -58,7 +67,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -75,6 +88,7 @@ import com.starry.myne.ui.common.ProgressDots
 import com.starry.myne.ui.common.simpleVerticalScrollbar
 import com.starry.myne.ui.screens.reader.main.activities.ReaderActivity
 import com.starry.myne.ui.screens.reader.main.activities.ReaderConstants
+import com.starry.myne.ui.screens.settings.viewmodels.SettingsViewModel
 import com.starry.myne.ui.theme.poppinsFont
 
 @Composable
@@ -88,7 +102,9 @@ fun ReaderDetailScreen(
     val readerData by (viewModel.progressData?.collectAsStateWithLifecycle(initialValue = null)
         ?: remember { mutableStateOf(null) })
 
-    LaunchedEffect(key1 = true) { viewModel.loadEbookData(libraryItemId, networkStatus) }
+    LaunchedEffect(key1 = true) {
+        viewModel.loadEbookData(libraryItemId, networkStatus)
+    }
 
     ReaderDetailScreen(
         libraryItemId = libraryItemId,
@@ -107,6 +123,78 @@ fun ReaderDetailScreen(
 ) {
     val context = LocalContext.current
 
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    /*
+    * Cases
+    * zen mode | notification policy access permission | action
+    * true     | true                                  | 1) Set up lifecycle events observer for start and stop.
+    * true     | true                                  | 2) On toggling of dnd through quick setting panel, update original dnd filter
+    * true     | false                                 | 3) Disable Zen mode
+    * */
+
+    val notificationManager : NotificationManager = remember {
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    val viewModel = (context.getActivity() as MainActivity).settingsViewModel
+
+    val enableZenMode by viewModel.enableZenMode.observeAsState(false)
+
+    if (enableZenMode && notificationManager.isNotificationPolicyAccessGranted) {
+        DisposableEffect(lifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                if (notificationManager.isNotificationPolicyAccessGranted){
+                    when (event) {
+                        Lifecycle.Event.ON_START -> {
+                            viewModel.originalFilter = notificationManager.currentInterruptionFilter
+                            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE)
+                            viewModel.isChangedManually=true
+                            Log.d("TRACKER","Start hit")
+                        }
+                        Lifecycle.Event.ON_STOP -> {
+                            notificationManager.setInterruptionFilter(viewModel.originalFilter)
+                            viewModel.isChangedManually=true
+                            Log.d("TRACKER","Stop hit")
+                        }
+                        else -> {}
+                    }
+                }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose {
+                lifecycleOwner.lifecycle.removeObserver(observer)
+                viewModel.isChangedManually=false
+            }
+        }
+        DisposableEffect(lifecycleOwner) {
+            val filterReceiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context?, intent: Intent?) {
+                    if (viewModel.isChangedManually){
+                        viewModel.isChangedManually=false
+                    }else{
+                        if (notificationManager.isNotificationPolicyAccessGranted) {
+                            viewModel.originalFilter=notificationManager.currentInterruptionFilter
+                        }
+                    }
+                    Log.d("TRACKER","Receiver hit")
+                }
+            }
+            ContextCompat.registerReceiver(
+                context,
+                filterReceiver,
+                IntentFilter(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED),
+                ContextCompat.RECEIVER_NOT_EXPORTED
+            )
+            onDispose {
+                context.unregisterReceiver(filterReceiver)
+            }
+        }
+    }
+
+    if (enableZenMode && !notificationManager.isNotificationPolicyAccessGranted){
+        viewModel.setEnableZenMode(false)
+    }
 
     Crossfade(targetState = state.isLoading, label = "ReaderDetailLoadingCrossFade") { isLoading ->
         if (isLoading) {

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/detail/ReaderDetailScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/detail/ReaderDetailScreen.kt
@@ -124,7 +124,6 @@ fun ReaderDetailScreen(
     val context = LocalContext.current
 
     val lifecycleOwner = LocalLifecycleOwner.current
-
     /*
     * Cases
     * zen mode | notification policy access permission | action

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/main/activities/ReaderActivity.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/main/activities/ReaderActivity.kt
@@ -16,27 +16,42 @@
 
 package com.starry.myne.ui.screens.reader.main.activities
 
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
 import android.content.ContentResolver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.starry.myne.MainActivity
 import com.starry.myne.R
 import com.starry.myne.helpers.Constants
+import com.starry.myne.helpers.getActivity
 import com.starry.myne.helpers.toToast
 import com.starry.myne.ui.screens.reader.main.composables.ChaptersContent
 import com.starry.myne.ui.screens.reader.main.composables.ReaderScreen
@@ -66,6 +81,78 @@ class ReaderActivity : AppCompatActivity() {
         // Set UI contents.
         setContent {
             MyneTheme(settingsViewModel = settingsViewModel) {
+                val context = LocalContext.current
+
+                val lifecycleOwner = LocalLifecycleOwner.current
+                /*
+                * Cases
+                * zen mode | notification policy access permission | action
+                * true     | true                                  | 1) Set up lifecycle events observer for start and stop.
+                * true     | true                                  | 2) On toggling of dnd through quick setting panel, update original dnd filter
+                * true     | false                                 | 3) Disable Zen mode
+                * */
+
+                val notificationManager : NotificationManager = remember {
+                    context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                }
+
+                val enableZenMode by settingsViewModel.enableZenMode.observeAsState(false)
+
+                if (enableZenMode && notificationManager.isNotificationPolicyAccessGranted) {
+                    DisposableEffect(lifecycleOwner) {
+                        val observer = LifecycleEventObserver { _, event ->
+                            if (notificationManager.isNotificationPolicyAccessGranted){
+                                when (event) {
+                                    Lifecycle.Event.ON_START -> {
+                                        settingsViewModel.originalFilter = notificationManager.currentInterruptionFilter
+                                        notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE)
+                                        settingsViewModel.isChangedManually=true
+                                        Log.d("TRACKER","Start hit")
+                                    }
+                                    Lifecycle.Event.ON_STOP -> {
+                                        notificationManager.setInterruptionFilter(settingsViewModel.originalFilter)
+                                        settingsViewModel.isChangedManually=true
+                                        Log.d("TRACKER","Stop hit")
+                                    }
+                                    else -> {}
+                                }
+                            }
+                        }
+                        lifecycleOwner.lifecycle.addObserver(observer)
+                        onDispose {
+                            lifecycleOwner.lifecycle.removeObserver(observer)
+                            settingsViewModel.isChangedManually=false
+                        }
+                    }
+                    DisposableEffect(lifecycleOwner) {
+                        val filterReceiver = object : BroadcastReceiver() {
+                            override fun onReceive(context: Context?, intent: Intent?) {
+                                if (settingsViewModel.isChangedManually){
+                                    settingsViewModel.isChangedManually=false
+                                }else{
+                                    if (notificationManager.isNotificationPolicyAccessGranted) {
+                                        settingsViewModel.originalFilter=notificationManager.currentInterruptionFilter
+                                    }
+                                }
+                                Log.d("TRACKER","Receiver hit")
+                            }
+                        }
+                        ContextCompat.registerReceiver(
+                            context,
+                            filterReceiver,
+                            IntentFilter(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED),
+                            ContextCompat.RECEIVER_NOT_EXPORTED
+                        )
+                        onDispose {
+                            context.unregisterReceiver(filterReceiver)
+                        }
+                    }
+                }
+
+                if (enableZenMode && !notificationManager.isNotificationPolicyAccessGranted){
+                    settingsViewModel.setEnableZenMode(false)
+                }
+
                 val lazyListState = rememberLazyListState()
                 val coroutineScope = rememberCoroutineScope()
                 // Handle intent and load epub book.

--- a/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
@@ -105,7 +105,7 @@ fun SettingsScreen(navController: NavController) {
 
     val snackBarHostState = remember { SnackbarHostState() }
 
-    val showAlertDialogBoxForRequestingNotificationPolicyAccess = viewModel.showAlertDialogBoxForRequestingNotificationPolicyAccess.observeAsState(initial = false).value
+    val showDndPermissionDialog = viewModel.showDndPermissionDialog.observeAsState(initial = false).value
 
     val notificationManager = remember { context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
 
@@ -132,28 +132,28 @@ fun SettingsScreen(navController: NavController) {
                 .background(MaterialTheme.colorScheme.background)
                 .padding(paddingValues)
         ) {
-            if (showAlertDialogBoxForRequestingNotificationPolicyAccess){
+            if (showDndPermissionDialog){
                 AlertDialog(
                     onDismissRequest = {
-                        viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess()
+                        viewModel.toggleShowDndPermissionDialog()
                     },
                     title = { Text(text = "Permission Required") },
                     text = {
-                        Text("To enable Zen Mode, this app needs 'Do Not Disturb' access. Please enable it in the system settings.")
+                        Text("To use Zen Mode, please grant \"Do Not Disturb\" access in your system settings.")
                     },
                     confirmButton = {
                         Button(
                             onClick = {
-                                viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess()
+                                viewModel.toggleShowDndPermissionDialog()
                                 val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
                                 context.startActivity(intent)
                             }
                         ) {
-                            Text("Go to Settings")
+                            Text("Open Settings")
                         }
                     },
                     dismissButton = {
-                        TextButton(onClick = { viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess() }) {
+                        TextButton(onClick = { viewModel.toggleShowDndPermissionDialog() }) {
                             Text("Cancel")
                         }
                     }
@@ -337,7 +337,7 @@ private fun GeneralOptionsUI(
             onCheckChange = {
                 val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
                 if (!notificationManager.isNotificationPolicyAccessGranted){
-                    viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess()
+                    viewModel.toggleShowDndPermissionDialog()
                 }else{
                     viewModel.setEnableZenMode(it)
                 }

--- a/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
@@ -16,6 +16,8 @@
 
 package com.starry.myne.ui.screens.settings.composables
 
+import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.provider.Settings
@@ -61,6 +63,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -102,6 +105,17 @@ fun SettingsScreen(navController: NavController) {
 
     val snackBarHostState = remember { SnackbarHostState() }
 
+    val showAlertDialogBoxForRequestingNotificationPolicyAccess = viewModel.showAlertDialogBoxForRequestingNotificationPolicyAccess.observeAsState(initial = false).value
+
+    val notificationManager = remember { context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
+
+    // in case the user turns off the permission in the background when the zen mode was enabled
+    // he would have to manually turn it on and have to grant the permission to use the mode again
+    LaunchedEffect(Unit) {
+        if (viewModel.enableZenMode.value==true && !notificationManager.isNotificationPolicyAccessGranted){
+            viewModel.setEnableZenMode(false)
+        }
+    }
     Scaffold(
         modifier = Modifier.padding(bottom = bottomNavPadding),
         snackbarHost = { SnackbarHost(snackBarHostState) },
@@ -118,6 +132,33 @@ fun SettingsScreen(navController: NavController) {
                 .background(MaterialTheme.colorScheme.background)
                 .padding(paddingValues)
         ) {
+            if (showAlertDialogBoxForRequestingNotificationPolicyAccess){
+                AlertDialog(
+                    onDismissRequest = {
+                        viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess()
+                    },
+                    title = { Text(text = "Permission Required") },
+                    text = {
+                        Text("To enable Zen Mode, this app needs 'Do Not Disturb' access. Please enable it in the system settings.")
+                    },
+                    confirmButton = {
+                        Button(
+                            onClick = {
+                                viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess()
+                                val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                                context.startActivity(intent)
+                            }
+                        ) {
+                            Text("Go to Settings")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess() }) {
+                            Text("Cancel")
+                        }
+                    }
+                )
+            }
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 SettingsCard()
                 GeneralOptionsUI(viewModel = viewModel, snackBarHostState = snackBarHostState)
@@ -213,6 +254,7 @@ private fun GeneralOptionsUI(
     val googleBooksApiSwitchState = viewModel.useGoogleApi.observeAsState(initial = true)
     val internalReaderState = viewModel.internalReader.observeAsState(initial = true)
     val openLibraryAtStartState = viewModel.openLibraryAtStart.observeAsState(initial = false)
+    val enableZenModeState = viewModel.enableZenMode.observeAsState(initial = false)
 
     val internalReaderValue = when (internalReaderState.value) {
         true -> stringResource(id = R.string.reader_option_inbuilt)
@@ -284,6 +326,21 @@ private fun GeneralOptionsUI(
             switchState = openLibraryAtStartState,
             onCheckChange = {
                 viewModel.setOpenLibraryAtStartValue(it)
+            }
+        )
+
+        SettingItemWIthSwitch(
+            icon = ImageVector.vectorResource(id = R.drawable.ic_book_pages),
+            mainText = "Enable Zen Mode",
+            subText = "Toggle DND when Reading",
+            switchState = enableZenModeState,
+            onCheckChange = {
+                val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                if (!notificationManager.isNotificationPolicyAccessGranted){
+                    viewModel.toggleAlertDialogBoxForRequestingNotificationPolicyAccess()
+                }else{
+                    viewModel.setEnableZenMode(it)
+                }
             }
         )
     }

--- a/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/settings/composables/SettingsScreen.kt
@@ -137,9 +137,9 @@ fun SettingsScreen(navController: NavController) {
                     onDismissRequest = {
                         viewModel.toggleShowDndPermissionDialog()
                     },
-                    title = { Text(text = "Permission Required") },
+                    title = { Text(text = stringResource(id = R.string.permission_required)) },
                     text = {
-                        Text("To use Zen Mode, please grant \"Do Not Disturb\" access in your system settings.")
+                        Text(stringResource(id = R.string.permission_required_desc))
                     },
                     confirmButton = {
                         Button(
@@ -149,12 +149,12 @@ fun SettingsScreen(navController: NavController) {
                                 context.startActivity(intent)
                             }
                         ) {
-                            Text("Open Settings")
+                            Text(stringResource(id = R.string.open_settings))
                         }
                     },
                     dismissButton = {
                         TextButton(onClick = { viewModel.toggleShowDndPermissionDialog() }) {
-                            Text("Cancel")
+                            Text(stringResource(id = R.string.cancel))
                         }
                     }
                 )
@@ -331,8 +331,8 @@ private fun GeneralOptionsUI(
 
         SettingItemWIthSwitch(
             icon = ImageVector.vectorResource(id = R.drawable.ic_book_pages),
-            mainText = "Enable Zen Mode",
-            subText = "Toggle DND when Reading",
+            mainText = stringResource(id = R.string.enable_zen_mode),
+            subText = stringResource(id = R.string.toggle_dnd_when_reading),
             switchState = enableZenModeState,
             onCheckChange = {
                 val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/main/java/com/starry/myne/ui/screens/settings/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/settings/viewmodels/SettingsViewModel.kt
@@ -50,7 +50,7 @@ class SettingsViewModel @Inject constructor(
     private val _openLibraryAtStart = MutableLiveData(false)
     private val _enableZenMode = MutableLiveData(false)
 
-    private val _showAlertDialogBoxForRequestingNotificationPolicyAccess = MutableLiveData(false)
+    private val _showDndPermissionDialog  = MutableLiveData(false)
 
     val theme: LiveData<ThemeMode> = _theme
     val amoledTheme: LiveData<Boolean> = _amoledTheme
@@ -60,7 +60,7 @@ class SettingsViewModel @Inject constructor(
     val openLibraryAtStart: LiveData<Boolean> = _openLibraryAtStart
     val enableZenMode : LiveData<Boolean> = _enableZenMode
 
-    val showAlertDialogBoxForRequestingNotificationPolicyAccess : LiveData<Boolean> = _showAlertDialogBoxForRequestingNotificationPolicyAccess
+    val showDndPermissionDialog  : LiveData<Boolean> = _showDndPermissionDialog
 
     init {
         _theme.value = ThemeMode.entries.toTypedArray()[getThemeValue()]
@@ -146,7 +146,7 @@ class SettingsViewModel @Inject constructor(
         } else theme.value!!
     }
 
-    fun toggleAlertDialogBoxForRequestingNotificationPolicyAccess(){
-        _showAlertDialogBoxForRequestingNotificationPolicyAccess.value=!_showAlertDialogBoxForRequestingNotificationPolicyAccess.value!!
+    fun toggleShowDndPermissionDialog(){
+        _showDndPermissionDialog.value=!_showDndPermissionDialog.value!!
     }
 }

--- a/app/src/main/java/com/starry/myne/ui/screens/settings/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/settings/viewmodels/SettingsViewModel.kt
@@ -16,9 +16,13 @@
 
 package com.starry.myne.ui.screens.settings.viewmodels
 
+import android.app.NotificationManager
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -35,12 +39,18 @@ class SettingsViewModel @Inject constructor(
     private val preferenceUtil: PreferenceUtil
 ) : ViewModel() {
 
+    var originalFilter: Int = NotificationManager.INTERRUPTION_FILTER_ALL
+    var isChangedManually by mutableStateOf(false)
+
     private val _theme = MutableLiveData(ThemeMode.Auto)
     private val _amoledTheme = MutableLiveData(false)
     private val _materialYou = MutableLiveData(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
     private val _internalReader = MutableLiveData(true)
     private val _useGoogleApi = MutableLiveData(true)
     private val _openLibraryAtStart = MutableLiveData(false)
+    private val _enableZenMode = MutableLiveData(false)
+
+    private val _showAlertDialogBoxForRequestingNotificationPolicyAccess = MutableLiveData(false)
 
     val theme: LiveData<ThemeMode> = _theme
     val amoledTheme: LiveData<Boolean> = _amoledTheme
@@ -48,6 +58,9 @@ class SettingsViewModel @Inject constructor(
     val internalReader: LiveData<Boolean> = _internalReader
     val useGoogleApi: LiveData<Boolean> = _useGoogleApi
     val openLibraryAtStart: LiveData<Boolean> = _openLibraryAtStart
+    val enableZenMode : LiveData<Boolean> = _enableZenMode
+
+    val showAlertDialogBoxForRequestingNotificationPolicyAccess : LiveData<Boolean> = _showAlertDialogBoxForRequestingNotificationPolicyAccess
 
     init {
         _theme.value = ThemeMode.entries.toTypedArray()[getThemeValue()]
@@ -56,6 +69,7 @@ class SettingsViewModel @Inject constructor(
         _internalReader.value = getInternalReaderValue()
         _useGoogleApi.value = getUseGoogleApiValue()
         _openLibraryAtStart.value = getOpenLibraryAtStartValue()
+        _enableZenMode.value = getEnableZenMode()
     }
 
     // Getters =============================================================================
@@ -90,6 +104,11 @@ class SettingsViewModel @Inject constructor(
         preferenceUtil.putBoolean(PreferenceUtil.OPEN_LIBRARY_AT_START_BOOL, newValue)
     }
 
+    fun setEnableZenMode(newValue: Boolean) {
+        _enableZenMode.postValue(newValue)
+        preferenceUtil.putBoolean(PreferenceUtil.ENABLE_ZEN_MODE_BOOL, newValue)
+    }
+
     // Getters ============================================================================
     // Used only during initialization except getCurrentTheme()
     private fun getThemeValue() = preferenceUtil.getInt(
@@ -116,10 +135,18 @@ class SettingsViewModel @Inject constructor(
         PreferenceUtil.OPEN_LIBRARY_AT_START_BOOL, false
     )
 
+    private fun getEnableZenMode() = preferenceUtil.getBoolean(
+        PreferenceUtil.ENABLE_ZEN_MODE_BOOL, false
+    )
+
     @Composable
     fun getCurrentTheme(): ThemeMode {
         return if (theme.value == ThemeMode.Auto) {
             if (isSystemInDarkTheme()) ThemeMode.Dark else ThemeMode.Light
         } else theme.value!!
+    }
+
+    fun toggleAlertDialogBoxForRequestingNotificationPolicyAccess(){
+        _showAlertDialogBoxForRequestingNotificationPolicyAccess.value=!_showAlertDialogBoxForRequestingNotificationPolicyAccess.value!!
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,4 +168,9 @@
 
     <!-- Open source libraries screen -->
     <string name="open_source_licenses_header">Licenses</string>
+    <string name="enable_zen_mode">Enable Zen Mode</string>
+    <string name="toggle_dnd_when_reading">Toggle DND when Reading</string>
+    <string name="permission_required">Permission Required</string>
+    <string name="permission_required_desc">To use Zen Mode, please grant \"Do Not Disturb\" access in your system settings.</string>
+    <string name="open_settings">Open Settings</string>
 </resources>


### PR DESCRIPTION
### Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Added a **Zen Mode** feature that automatically toggles "Do Not Disturb" (DND) when the user enters the In-built Reader.

**Motivation & Context:**
Enhances the reading experience by preventing notification interruptions. The state is handled by preserving the user's original DND settings upon entering the reader and restoring them once the activity stops.

Key Changes:
- Added a Zen Mode toggle in the GeneralOptionsUI composable.
- Implemented DND management logic tied to the Reader activity lifecycle.
- Added state preservation to ensure the user's device returns to its original ringer mode after reading.

Pending Items:
- [x] Finalize "Zen Mode" Title and Sub-title strings in General Settings.
- [ ] Additional edge-case testing (e.g., app crashing while DND is on).

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/Pool-Of-Tears/Myne/issues/266

## Type of change 
<!--- Is this a bug fix, adding a feature... -->
Adding a toggle in GeneralOptionsUI composable. Once enabled, when user opens the inBuilt Reader, user's settings get preserved and the app turns on DND when the app's activity starts and the preserved state is restored when the activity stops.

### Pull Request checklist
<!-- Before submitting the PR, please address each item. Use [x] to check the boxes -->
- [x] The commit message uses the [conventional commiting method][conv-commits].
- [x] Made sure that your PR is not duplicate
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (*optional*)

[conv-commits]:https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index