### PR TITLE
feat: Add sepia mode toggle for reader screen

### DIFF
--- a/app/src/main/java/com/starry/myne/helpers/Preferencesutils.kt
+++ b/app/src/main/java/com/starry/myne/helpers/Preferencesutils.kt
@@ -45,6 +45,7 @@ class PreferenceUtil(context: Context) {
         const val READER_LINE_HEIGHT_FLOAT = "reader_line_height"
         const val READER_AUTO_SCROLL_SPEED_FLOAT = "reader_auto_scroll_speed"
         const val READER_DND_BOOL = "reader_dnd"
+        const val READER_SEPIA_MODE_BOOL = "reader_sepia_mode"
 
         // Home screen preference keys
         const val PREFERRED_BOOK_LANG_STR = "preferred_book_language"

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/main/composables/ChaptersContent.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/main/composables/ChaptersContent.kt
@@ -67,6 +67,8 @@ import com.starry.myne.helpers.toToast
 import com.starry.myne.ui.common.MyneSelectionContainer
 import com.starry.myne.ui.screens.reader.main.viewmodel.ReaderScreenState
 import com.starry.myne.ui.theme.pacificoFont
+import com.starry.myne.ui.theme.readerSepiaBackground
+import com.starry.myne.ui.theme.readerSepiaText
 
 
 @Composable
@@ -77,7 +79,11 @@ fun ChaptersContent(
     onLoadImage: (String) -> Unit
 ) {
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .let {
+                if (state.isSepiaModeEnabled) it.background(readerSepiaBackground) else it
+            },
         state = lazyListState
     ) {
         items(
@@ -235,7 +241,8 @@ private fun ChapterLazyItemItem(
                 lineHeight = 1.3f.em,
                 fontFamily = pacificoFont,
                 fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.88f)
+                color = (if (state.isSepiaModeEnabled) readerSepiaText else MaterialTheme.colorScheme.onBackground)
+                    .copy(alpha = 0.88f)
             )
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -251,6 +258,8 @@ private fun ChapterLazyItemItem(
                             lineHeight = lineHeight.em,
                             fontFamily = state.fontFamily.fontFamily,
                             modifier = Modifier.padding(start = 14.dp, end = 14.dp, bottom = 8.dp),
+                            color = if (state.isSepiaModeEnabled) readerSepiaText
+                            else Color.Unspecified,
                         )
                     }
 
@@ -300,7 +309,8 @@ private fun ChapterLazyItemItem(
                                 text = annotatedString,
                                 fontSize = (fontSize * 0.9f).sp,
                                 fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
-                                color = MaterialTheme.colorScheme.onSurface
+                                color = if (state.isSepiaModeEnabled) readerSepiaText
+                                else MaterialTheme.colorScheme.onSurface
                             )
                         }
                     }
@@ -311,7 +321,10 @@ private fun ChapterLazyItemItem(
                                 .fillMaxWidth()
                                 .padding(horizontal = 14.dp, vertical = 8.dp)
                                 .clip(RoundedCornerShape(8.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                                .background(
+                                    if (state.isSepiaModeEnabled) Color.Black.copy(alpha = 0.06f)
+                                    else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                                )
                                 .padding(16.dp)
                         ) {
                             val annotatedString =
@@ -324,7 +337,8 @@ private fun ChapterLazyItemItem(
                                 fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
                                 lineHeight = lineHeight.em,
                                 fontFamily = state.fontFamily.fontFamily,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+                                color = (if (state.isSepiaModeEnabled) readerSepiaText
+                                else MaterialTheme.colorScheme.onSurface).copy(alpha = 0.8f)
                             )
                         }
                     }
@@ -334,7 +348,8 @@ private fun ChapterLazyItemItem(
 
         HorizontalDivider(
             thickness = 2.dp,
-            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.2f)
+            color = (if (state.isSepiaModeEnabled) readerSepiaText
+            else MaterialTheme.colorScheme.onBackground).copy(alpha = 0.2f)
         )
     }
 }

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/main/composables/ReaderBottomBar.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/main/composables/ReaderBottomBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Tonality
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
@@ -62,7 +63,8 @@ fun ReaderBottomBar(
     onFontSizeChanged: (newValue: Int) -> Unit,
     onLineHeightChanged: (newValue: Float) -> Unit,
     onToggleAutoScroll: () -> Unit,
-    onAutoScrollSpeedChanged: (newValue: Float) -> Unit
+    onAutoScrollSpeedChanged: (newValue: Float) -> Unit,
+    onToggleSepiaMode: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -95,6 +97,44 @@ fun ReaderBottomBar(
             readerFontFamily = state.fontFamily,
             showFontDialog = showFontDialog
         )
+        Spacer(modifier = Modifier.height(16.dp))
+        SepiaModeButton(
+            isSepiaModeEnabled = state.isSepiaModeEnabled,
+            onToggleSepiaMode = onToggleSepiaMode
+        )
+    }
+}
+
+@Composable
+private fun SepiaModeButton(
+    isSepiaModeEnabled: Boolean,
+    onToggleSepiaMode: () -> Unit
+) {
+    FilledTonalButton(
+        onClick = onToggleSepiaMode,
+        modifier = Modifier
+            .fillMaxWidth(0.9f)
+            .height(45.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = if (isSepiaModeEnabled) {
+            ButtonDefaults.filledTonalButtonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            )
+        } else {
+            ButtonDefaults.filledTonalButtonColors()
+        }
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(imageVector = Icons.Filled.Tonality, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(
+                    id = if (isSepiaModeEnabled) R.string.reader_sepia_mode_on
+                    else R.string.reader_sepia_mode_off
+                )
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/main/composables/ReaderScreen.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/main/composables/ReaderScreen.kt
@@ -155,7 +155,8 @@ fun ReaderScreen(
                         onFontSizeChanged = { viewModel.setFontSize(it) },
                         onLineHeightChanged = { viewModel.setLineHeight(it) },
                         onToggleAutoScroll = { viewModel.toggleAutoScroll() },
-                        onAutoScrollSpeedChanged = { viewModel.setAutoScrollSpeed(it) }
+                        onAutoScrollSpeedChanged = { viewModel.setAutoScrollSpeed(it) },
+                        onToggleSepiaMode = { viewModel.toggleSepiaMode() }
                     )
                 }
             },

--- a/app/src/main/java/com/starry/myne/ui/screens/reader/main/viewmodel/ReaderViewModel.kt
+++ b/app/src/main/java/com/starry/myne/ui/screens/reader/main/viewmodel/ReaderViewModel.kt
@@ -68,6 +68,8 @@ data class ReaderScreenState(
     // Auto scroll
     val isAutoScrollActive: Boolean = false,
     val autoScrollSpeed: Float = 1.0f,
+    // Reader page theme
+    val isSepiaModeEnabled: Boolean = false,
 )
 
 @HiltViewModel
@@ -104,6 +106,10 @@ class ReaderViewModel @Inject constructor(
                     autoScrollSpeed = preferenceUtil.getFloat(
                         PreferenceUtil.READER_AUTO_SCROLL_SPEED_FLOAT,
                         1.0f
+                    ),
+                    isSepiaModeEnabled = preferenceUtil.getBoolean(
+                        PreferenceUtil.READER_SEPIA_MODE_BOOL,
+                        false
                     )
                 )
             }
@@ -356,6 +362,12 @@ class ReaderViewModel @Inject constructor(
     fun setAutoScrollSpeed(newValue: Float) {
         preferenceUtil.putFloat(PreferenceUtil.READER_AUTO_SCROLL_SPEED_FLOAT, newValue)
         _state.update { it.copy(autoScrollSpeed = newValue) }
+    }
+
+    fun toggleSepiaMode() {
+        val newValue = !state.value.isSepiaModeEnabled
+        preferenceUtil.putBoolean(PreferenceUtil.READER_SEPIA_MODE_BOOL, newValue)
+        _state.update { it.copy(isSepiaModeEnabled = newValue) }
     }
 
 }

--- a/app/src/main/java/com/starry/myne/ui/theme/Color.kt
+++ b/app/src/main/java/com/starry/myne/ui/theme/Color.kt
@@ -91,3 +91,6 @@ val surfaceContainerLowDark = Color(0xFF171C1F)
 val surfaceContainerDark = Color(0xFF1B2023)
 val surfaceContainerHighDark = Color(0xFF252B2D)
 val surfaceContainerHighestDark = Color(0xFF303638)
+
+val readerSepiaBackground = Color(0xFFF4ECD8)
+val readerSepiaText = Color(0xFF5B4636)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,8 @@
     <string name="reader_bookmarks_list_title">Bookmarks</string>
     <string name="reader_bookmark_added">Bookmark added</string>
     <string name="reader_bookmark_removed">Bookmark removed</string>
+    <string name="reader_sepia_mode_on">Sepia Mode: On</string>
+    <string name="reader_sepia_mode_off">Sepia Mode: Off</string>
     <string name="reader_auto_scroll_start">Start Auto Scroll</string>
     <string name="reader_auto_scroll_stop">Stop Auto Scroll</string>
 


### PR DESCRIPTION
  Adds a Sepia toggle in the reader's bottom sheet that switches the book page background/text to warm sepia tones for reduced eye strain, independent of the app's overall theme.

Closes #74 