### PR TITLE
fix: add polling interval to download progress loop

### DIFF
--- a/app/src/main/java/com/starry/myne/helpers/book/BookDownloader.kt
+++ b/app/src/main/java/com/starry/myne/helpers/book/BookDownloader.kt
@@ -44,6 +44,7 @@ class BookDownloader(private val context: Context) {
         const val BOOKS_FOLDER = "ebooks"
         const val TEMP_FOLDER = "temp_books"
         private const val MAX_FILENAME_LENGTH = 100
+        private const val DOWNLOAD_POLL_INTERVAL_MS = 250L
 
         /**
          * Sanitizes book title by replacing forbidden chars which are not allowed
@@ -195,6 +196,7 @@ class BookDownloader(private val context: Context) {
                 downloadProgressListener(progress, status)
                 runningDownloads[book.id]?.progress?.value = progress
                 cursor.close()
+                if (!isDownloadFinished) delay(DOWNLOAD_POLL_INTERVAL_MS)
             }
             /**
             Remove download from running downloads when loop ends.


### PR DESCRIPTION
### Description
The progress polling loop in `BookDownloader.downloadBook` had no delay, so it hit
DownloadManager and allocated a new Cursor every iteration for the whole download.
Measured ~198 queries/sec on a Pixel.

Adds a 250ms wait between polls. It sits at the bottom of the loop behind
`if (!isDownloadFinished)`, so the first progress update still goes out right away and
finishing doesn't get held up an extra 250ms.

Same phone and build, both successful downloads:

  before: 796 iterations in 4022ms (~198/sec)
  after:   16 iterations in 4083ms (~3.9/sec)

### Related Issue
Closes #305

## Type of change
Bug fix, though it's really cleanup. Nothing users would notice.

### Pull Request checklist
- [x] The commit message uses the conventional commiting method.
- [x] Made sure that your PR is not duplicate
- [x] **Tests**: Nothing automated, the loop needs a real DownloadManager and an actual
      download. Checked it by hand with a counter in the loop, numbers are in #305.
- [x] **Screenshots**: Nothing visual changed.